### PR TITLE
Add book to Python recommended reading list

### DIFF
--- a/src/community/recommended_readings.rst
+++ b/src/community/recommended_readings.rst
@@ -22,8 +22,11 @@ Programming Languages
 Python
 ++++++
 
-* `Python in a Nutshell <http://shop.oreilly.com/product/0636920012610.do>`_ is a comprehensive python reference to have on your desk while developing any sort of python application.
-* `Python testing with pytest <https://pragprog.com/book/bopytest/python-testing-with-pytest>`_ covers pytest framework and related testing best practices in the python ecosystem.
+* `Python in a Nutshell <http://shop.oreilly.com/product/0636920012610.do>`_ is a comprehensive Python reference to have on your desk while developing any sort of Python application.
+* `Python testing with pytest <https://pragprog.com/book/bopytest/python-testing-with-pytest>`_ covers pytest framework and related testing best practices in the Python ecosystem.
+* `Fluent Python <http://shop.oreilly.com/product/0636920032519.do>`_ is a useful guide to writing effective, idiomatic
+  Python code. This book is recommended reading for intermediate Python developers and those coming from other
+  languages, showing how Python features and idioms should be used most effectively.
 
 C++
 +++
@@ -31,3 +34,4 @@ C++
 * `Effective C++ <https://www.amazon.co.uk/Effective-Specific-Programs-Professional-Computing/dp/0321334876>`_ contains useful recipes for sound implementations of common C++ patterns.
 * `Effective STL <https://www.amazon.co.uk/Effective-Specific-Programs-Professional-Computing/dp/0321334876>`_ focuses on the correct usage of the standard teamplate library.
 * `Effective Modern C++ <http://shop.oreilly.com/product/0636920033707.do>`_ follows from the previous series, expanding on the transition to C++11 and C++14 and their new constructs.
+


### PR DESCRIPTION
I've added Fluent Python as a recommendation to the Python reading list. I found Fluent Python to be a useful illustration of how to write better, more Pythonic code and move away from a Java/C++ way of thinking.