### PR TITLE
ST-171 Hosting docker images on Nexus procedure

### DIFF
--- a/src/development/uploading-docker-nexus.rst
+++ b/src/development/uploading-docker-nexus.rst
@@ -17,7 +17,7 @@ To explicitly tag a docker image run the following command.
 
 .. code:: bash
 
-  $ docker tag ubuntu:16.04 nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
+  $ docker tag <source_image> nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
 
 Uploading the docker image to *NEXUS*
 -------------------------------------

--- a/src/development/uploading-docker-nexus.rst
+++ b/src/development/uploading-docker-nexus.rst
@@ -21,7 +21,8 @@ To explicitly tag a docker image run the following command:
 
 This command will create an alias by the name of the :code:`<image_name>` that refers to the :code:`<source_image>`.
 
-**Note that naming and tagging conventions are outlined in the containerisation standards.**
+**Note that naming and tagging conventions are outlined in the containerisation standards. And those should follow
+the same semantic versioning used for the repository.**
 
 Uploading the docker image to *NEXUS*
 -------------------------------------

--- a/src/development/uploading-docker-nexus.rst
+++ b/src/development/uploading-docker-nexus.rst
@@ -1,0 +1,30 @@
+.. _registry: https://nexus.engageska-portugal.pt/#browse/search/docker
+
+==============================================
+Hosting a docker image on the *Nexus* registry
+==============================================
+
+As part of our goal to align all developmental efforts to one standard, we have documented
+a procedure of how we would like all the *SKA* developers to version tag their docker images
+and what process to follow in ensuring that they are able to make use of the existing Gitlab CI/CD
+pipeline to automate the building of docker images, for now, and have them published on
+the *SKA* docker registry_ which is hosted on *Nexus*.
+
+Tagging the docker image
+------------------------
+
+To explicitly tag a docker image run the following command.
+
+.. code:: bash
+
+  $ docker tag ubuntu:16.04 nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
+
+Uploading the docker image to *NEXUS*
+-------------------------------------
+
+Once the docker image has been built and tagged, it can then be uploaded to the *Nexus* registry
+by executing the following command:
+
+.. code:: bash
+
+  $ docker push nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>

--- a/src/development/uploading-docker-nexus.rst
+++ b/src/development/uploading-docker-nexus.rst
@@ -13,11 +13,15 @@ the *SKA* docker registry_ which is hosted on *Nexus*.
 Tagging the docker image
 ------------------------
 
-To explicitly tag a docker image run the following command.
+To explicitly tag a docker image run the following command:
 
 .. code:: bash
 
   $ docker tag <source_image> nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
+
+This command will create an alias by the name of the :code:`<image_name>` that refers to the :code:`<source_image>`.
+
+**Note that naming and tagging conventions are outlined in the containerisation standards.**
 
 Uploading the docker image to *NEXUS*
 -------------------------------------

--- a/src/development/uploading-docker-nexus.rst
+++ b/src/development/uploading-docker-nexus.rst
@@ -17,7 +17,7 @@ To explicitly tag a docker image run the following command:
 
 .. code:: bash
 
-  $ docker tag <source_image> nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
+  $ docker tag <source_image> nexus.engageska-portugal.pt/<repository_name>/<image_name>:<tag_name>
 
 This command will create an alias by the name of the :code:`<image_name>` that refers to the :code:`<source_image>`.
 
@@ -31,4 +31,4 @@ by executing the following command:
 
 .. code:: bash
 
-  $ docker push nexus.engageska-portugal.pt/<repository_name>/<image_name>/<tag_name>
+  $ docker push nexus.engageska-portugal.pt/<repository_name>/<image_name>:<tag_name>

--- a/src/index.rst
+++ b/src/index.rst
@@ -150,6 +150,7 @@ The definition of done is used to guide teams in planning and estimating the siz
   development/javascript-codeguide
   development/containerisation-standards
   development/python_package_release_procedure
+  development/uploading-docker-nexus
 
 
 Development guidelines
@@ -198,6 +199,14 @@ This details a procedure that all *SKA* developers shall follow to ensure that t
 existing CI/CD pipelines to automate the building of their software packages for release.
 
 - :doc:`development/python_package_release_procedure`
+
+Hosting a docker image on Nexus
+===============================
+
+This details steps that all *SKA* developers shall abide to when building and hosting their docker
+images on the Nexus registry.
+
+- :doc:`development/uploading-docker-nexus`
 
 
 .. PROJECTS SECTION ==================================================


### PR DESCRIPTION
This describes the process that a developer shall follow when tagging new versions of the docker images and how to upload them to the _SKA_ docker registry hosted on [Nexus](https://nexus.engageska-portugal.pt/#browse/search/docker).


JIRA: [ST-171](https://jira.skatelescope.org/browse/ST-171)