### PR TITLE
ZEROMQ and OMNIORB versions updated

### DIFF
--- a/src/tools/tango-devenv-setup.rst
+++ b/src/tools/tango-devenv-setup.rst
@@ -13,8 +13,8 @@ Tools include:
  - g++ 7.3.0 (default ubuntu 18.04)
  - TANGO-controls '9.2.5a'
  - Visual Studio Code '1.30', PyCharm Community Edition 'community-2018.3.3'
- - ZEROMQ '4.0.5'
- - OMNIORB '4.2.1'
+ - ZEROMQ '4.0.8'
+ - OMNIORB '4.2.3'
  
 Processes include:
  - writing code,


### PR DESCRIPTION
* OMNIORB was updated to version 4.2.3: The version 4.2.1 being used had a race condition bug described under (https://sourceforge.net/p/tango-cs/bugs/794/) that needed a patch. This version of OMNIORB fixes that bug and the patch is not needed anymore.

* ZEROMQ was updated to 4.0.8 which is the supported version from the 4.0.x series. The developers do advise the use of the lates stable 4.3.1 though, and we should consider that (both were added to the Nexus).