### PR TITLE
ST-234 Collecting & consolidating CI health metrics as part of the CI pipeline

### DIFF
--- a/src/tools/continuousintegration.rst
+++ b/src/tools/continuousintegration.rst
@@ -88,7 +88,7 @@ the root of the repositories they have ownership over.
 The :code:`ci-metrics.json` file is expect to be created automatically as part
 of the CI pipeline by the teams by collecting the relevant information from the
 *unit tests*, *coverage*, *linting* and *build status*.
-**An important point to notice, is that :code:`ci-metrics.json` shouldn't exist
+**An important point to notice, is that** :code:`ci-metrics.json` **shouldn't exist
 as part of the repository, but, be created specifically as part of the CI
 pipeline.**
 The file must be created and properly populated before the start of the marked

--- a/src/tools/continuousintegration.rst
+++ b/src/tools/continuousintegration.rst
@@ -79,12 +79,21 @@ the button “Run pipeline” on a specific branch (i.e. master).
 
 |image5|
 
-Collecting code health metrics in the CI pipeline
--------------------------------------------------
-As part of the CI/CD process all teams are expected to collect and consolidate the necessary code health metrics under a file named **codeMetrics.json** at the root of the repositories they have ownership over.
+Collecting & consolidating CI health metrics as part of the CI pipeline
+-----------------------------------------------------------------------
+As part of the CI/CD process all teams are expected to collect and consolidate
+the necessary code health metrics under a file named :code:`ci-metrics.json` at
+the root of the repositories they have ownership over.
 
-The **codeMetrics.json** file is expect to be created automatically as part of the CI pipeline by the teams by collecting the relevant information from the *unit tests*, *coverage*, *linting* and *build status*.
-The file must be created and properly populated before the start of the marked :code:`# START: Gitlab CI badges creation` in the *pages* stage of the CI pipeline (**.gitlab-ci.yml** file).
+The :code:`ci-metrics.json` file is expect to be created automatically as part
+of the CI pipeline by the teams by collecting the relevant information from the
+*unit tests*, *coverage*, *linting* and *build status*.
+**An important point to notice, is that :code:`ci-metrics.json` shouldn't exist
+as part of the repository, but, be created specifically as part of the CI
+pipeline.**
+The file must be created and properly populated before the start of the marked
+:code:`# START: Gitlab CI badges creation` in the **pages** stage of the CI
+pipeline (:code:`.gitlab-ci.yml` file).
 
 The metrics should be collected under the following structure:
 
@@ -92,12 +101,14 @@ The metrics should be collected under the following structure:
 
   - last: *placeholder about the last build process*
 
-    - status: (**string**) *failed or passed, stating that last build status*
-    - timestamp: (**float**) *the Unix timestamp with the date and time of the last build status*
+    - status: (**string**) *failed or passed, stating the last build status*
+    - timestamp: (**float**) *the Unix timestamp with the date and time of the
+      last build status*
 
-  .. - green: *placeholder about the last green build process*
+  - green: *placeholder about the last green build process*
 
-  ..   - timestamp: (**float**) *the Unix timestamp with the date and time of the last successful build status*
+    - timestamp: (**float**) *the Unix timestamp with the date and time of the
+      last successful build status*
 
 - coverage: *placeholder about the unit test coverage*
 
@@ -112,34 +123,55 @@ The metrics should be collected under the following structure:
 - tests: *placeholder about the linting (static code analysis)*
 
   - errors: (**int**) *number of linting errors*
-  - failures: (**int**) *number of linting failures* - this denotes a serious error in the code that broke the linting process
+  - failures: (**int**) *number of linting failures* - this denotes a serious
+    error in the code that broke the linting process
   - tests: (**int**) *total number of linting tests*
 
-**codeMetrics.json** example:
+:code:`ci-metrics.json` example:
 
 .. code-block:: json
 
   {
-      "build-status": {
-          "last": {
-              "status": "failed",
-              "timestamp": 1568202193.0
-          }
-      },
-      "coverage": {
-          "percentage": 60.00
-          },
-      "tests": {
-          "passed": 167,
-          "failed": 3,
-          "total": 170
-      },
-      "lint": {
-          "errors": 4,
-          "failures": 0,
-          "tests": 7
-      }
-  }
+    "build-status": {
+        "last": {
+            "status": "failed",
+            "timestamp": 1568202193.0
+        },
+        "green": {
+            "timestamp": 1568112133.0
+        }
+    },
+    "coverage": {
+        "percentage": 60.00
+        },
+    "tests": {
+        "passed": 167,
+        "failed": 3,
+        "total": 170
+    },
+    "lint": {
+        "errors": 4,
+        "failures": 0,
+        "tests": 7
+    }
+}
+
+
+Besides the :code:`ci-metrics.json` the teams should provide the relevant
+output from the **test** and **linting** stage used to extract those metrics
+for the *unit test*, *coverage* and *linting* under specific files in JSON
+format for easy access as part of the published artifacts on the pages stage
+of the CI pipeline:
+
+- :code:`/public/reports/unit-tests.json`
+- :code:`/public/reports/code-coverage.json`
+- :code:`/public/reports/linting.json`
+
+It is up to the teams to decide the best way to generate these report files,
+and they are provided with the purpose of easy inspection of the results
+directly from their respective Gitlab repository by clicking on the respective
+badges. As such, their format doesn't need to be standardized, but only to
+follow the JSON file format.
 
 
 Using a specific executor

--- a/src/tools/continuousintegration.rst
+++ b/src/tools/continuousintegration.rst
@@ -83,13 +83,14 @@ Collecting & consolidating CI health metrics as part of the CI pipeline
 -----------------------------------------------------------------------
 As part of the CI/CD process all teams are expected to collect and consolidate
 the necessary code health metrics under a file named :code:`ci-metrics.json` at
-the root of the repositories they have ownership over.
+created at Gitlab CI pipeline runtime under the root folder for that
+repository.
 
 The :code:`ci-metrics.json` file is expect to be created automatically as part
 of the CI pipeline by the teams by collecting the relevant information from the
 *unit tests*, *coverage*, *linting* and *build status*.
-**An important point to notice, is that** :code:`ci-metrics.json` **shouldn't exist
-as part of the repository, but, be created specifically as part of the CI
+**An important point to notice, is that** :code:`ci-metrics.json` **shouldn't
+exist as part of the repository, but, be created specifically as part of the CI
 pipeline.**
 The file must be created and properly populated before the start of the marked
 :code:`# START: Gitlab CI badges creation` in the **pages** stage of the CI
@@ -159,20 +160,18 @@ The metrics should be collected under the following structure:
 
 Besides the :code:`ci-metrics.json` the teams should provide the relevant
 output from the **test** and **linting** stage used to extract those metrics
-for the *unit test*, *coverage* and *linting* under specific files in JSON
-format for easy access as part of the published artifacts on the pages stage
-of the CI pipeline:
+for the *unit tests*, *code coverage* and *linting* under the following specific
+files in XML format for easy access as part of the published artifacts on the
+pages stage of the CI pipeline:
 
-- :code:`/public/reports/unit-tests.json`
-- :code:`/public/reports/code-coverage.json`
-- :code:`/public/reports/linting.json`
+- :code:`/build/reports/unit-tests.xml`: JUnit XML Format
+- :code:`/build/reports/code-coverage.xml`: Standard XML Format
+- :code:`/build/reports/linting.xml`: Standard XML Format
 
 It is up to the teams to decide the best way to generate these report files,
 and they are provided with the purpose of easy inspection of the results
 directly from their respective Gitlab repository by clicking on the respective
-badges. As such, their format doesn't need to be standardized, but only to
-follow the JSON file format.
-
+badges and for historical metrics collection.
 
 Using a specific executor
 -------------------------

--- a/src/tools/continuousintegration.rst
+++ b/src/tools/continuousintegration.rst
@@ -79,6 +79,69 @@ the button “Run pipeline” on a specific branch (i.e. master).
 
 |image5|
 
+Collecting code health metrics in the CI pipeline
+-------------------------------------------------
+As part of the CI/CD process all teams are expected to collect and consolidate the necessary code health metrics under a file named **codeMetrics.json** at the root of the repositories they have ownership over.
+
+The **codeMetrics.json** file is expect to be created automatically as part of the CI pipeline by the teams by collecting the relevant information from the *unit tests*, *coverage*, *linting* and *build status*.
+The file must be created and properly populated before the start of the marked :code:`# START: Gitlab CI badges creation` in the *pages* stage of the CI pipeline (**.gitlab-ci.yml** file).
+
+The metrics should be collected under the following structure:
+
+- build-status: *top level placeholder for the build process status*
+
+  - last: *placeholder about the last build process*
+
+    - status: (**string**) *failed or passed, stating that last build status*
+    - timestamp: (**float**) *the Unix timestamp with the date and time of the last build status*
+
+  .. - green: *placeholder about the last green build process*
+
+  ..   - timestamp: (**float**) *the Unix timestamp with the date and time of the last successful build status*
+
+- coverage: *placeholder about the unit test coverage*
+
+  - percentage: (**float**) *the coverage percentage of the unit tests*
+
+- tests: *placeholder about the unit tests*
+
+  - passed: (**int**) *number of successful tests*
+  - failed: (**int**) *number of failed tests*
+  - total: (**int**) *total number of tests*
+
+- tests: *placeholder about the linting (static code analysis)*
+
+  - errors: (**int**) *number of linting errors*
+  - failures: (**int**) *number of linting failures* - this denotes a serious error in the code that broke the linting process
+  - tests: (**int**) *total number of linting tests*
+
+**codeMetrics.json** example:
+
+.. code-block:: json
+
+  {
+      "build-status": {
+          "last": {
+              "status": "failed",
+              "timestamp": 1568202193.0
+          }
+      },
+      "coverage": {
+          "percentage": 60.00
+          },
+      "tests": {
+          "passed": 167,
+          "failed": 3,
+          "total": 170
+      },
+      "lint": {
+          "errors": 4,
+          "failures": 0,
+          "tests": 7
+      }
+  }
+
+
 Using a specific executor
 -------------------------
 


### PR DESCRIPTION
Added a new section on the CI page of the developer portal named: Collecting & consolidating CI health metrics as part of the CI pipeline

This section described where to collect and consolidate several information about code and CI pipeline health so that it can be easily available for several inspection purposes.